### PR TITLE
mod clone method

### DIFF
--- a/src/core/src/lib/utils.spec.ts
+++ b/src/core/src/lib/utils.spec.ts
@@ -150,6 +150,19 @@ describe('clone', () => {
     expect(clone(d)).toEqual(d);
     expect(clone(d) === d).toBeFalsy();
   });
+  it('Object with methods', () => {
+    class Foo {
+      constructor(public foo = '') {}
+      method() { return this.foo; }
+    }
+    const foo = new Foo('test');
+    const clonedFoo = clone(foo);
+    expect(clonedFoo).toEqual(foo);
+    expect(clonedFoo === foo).toBeFalsy();
+    // method of the base class have been copied
+    expect(clonedFoo.method).toBeTruthy();
+    expect(clonedFoo.method()).toEqual(foo.method());
+  });
 
   it('Enumerable getter', () => {
     const d = {};

--- a/src/core/src/lib/utils.ts
+++ b/src/core/src/lib/utils.ts
@@ -118,7 +118,7 @@ export function clone(value: any): any {
     return value.slice(0).map(v => clone(v));
   }
 
-  if (calue.clone && value.clone()) {
+  if (value.clone && value.clone()) {
     return value.clone();
   }
 

--- a/src/core/src/lib/utils.ts
+++ b/src/core/src/lib/utils.ts
@@ -118,21 +118,9 @@ export function clone(value: any): any {
     return value.slice(0).map(v => clone(v));
   }
 
-  if (value.clone && value.clone()) {
-    return value.clone();
-  }
-
-  return Object.keys(value).reduce((newVal, prop) => {
-    const propDescriptor = Object.getOwnPropertyDescriptor(value, prop);
-
-    if (propDescriptor.get) {
-      Object.defineProperty(newVal, prop, { ...propDescriptor, get: () => clone(value[prop]) });
-    } else {
-      newVal[prop] = clone(value[prop]);
-    }
-
-    return newVal;
-  }, {});
+  // best way to clone a js object maybe
+  // https://stackoverflow.com/questions/41474986/how-to-clone-a-javascript-es6-class-instance
+  return Object.assign(Object.create( Object.getPrototypeOf(value)), value);
 }
 
 export function defineHiddenProp(field, prop, defaultValue) {

--- a/src/core/src/lib/utils.ts
+++ b/src/core/src/lib/utils.ts
@@ -118,6 +118,10 @@ export function clone(value: any): any {
     return value.slice(0).map(v => clone(v));
   }
 
+  if (calue.clone && value.clone()) {
+    return value.clone();
+  }
+
   return Object.keys(value).reduce((newVal, prop) => {
     const propDescriptor = Object.getOwnPropertyDescriptor(value, prop);
 


### PR DESCRIPTION
if a value is an object that knows how to clone itself, we use that instead of copying each property
ensures the cloned value is of the same type of the value when possible

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

it's a bugfix/feature, depending how you see it. see #1719 for more info

**What is the current behavior? (You can also link to an open issue here)**
 see #1719


**What is the new behavior (if this is a feature change)?**

ensure the `clone` method creates an object of the same `type` when this type knows how to clone itself

for example, for a class Foo that implements a method `clone`
```ts
import { clone } from 'utils';
class Foo {
  constructor(public name: string) {}
  clone() { return new Foo(this.name); }
  isFoo() { return true; }
}
const foo = new Foo('test');
const clonedFoo = clone(foo);
console.log(clonedFoo.name); // 'test'
console.log(clonedFoo.isFoo()); // true
```

but for a class that doesn't, the current behavior is unchanged, the clone method copies all properties but not the methods and the type of the original value is lost

```ts
import { clone } from 'utils';
class Bar {
  constructor(public name: string) {}
  isBar() { return true; }
}
const bar = new Bar('test');
const clonedBar = clone(bar);
console.log(clonedBar.isBar()); // throws
```

**Please check if the PR fulfills these requirements**
- [ ] The commit messages follow our guidelines: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit-message-format
- [ ] A unit test has been written for this change.
- [ ] Running `npm run build` produced a successful build. (Unit testing can be done by running `npm test`;)
- [ ] My code has been linted. (`npm run lint` to do this. `npm run build` will fail if there are files not linted.)

none of that, i did it from github, and i didnt read the contributing guideline beforehand. i can redo it if you're interested

**Please provide a screenshot of this feature before and after your code changes, if applicable.**



**Other information**:
